### PR TITLE
Add instruction clarifications and correct test bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ function getStarshipPassengerAndCrewSumTotal (character) {
  * ### Challenge `getNthFilm`
  * @instructions
  * Return the Nth `films` value (in this case title).
- * Rules: N starts at 1, and includes only the range 1-3.
+ * Rules: filmNumber starts at 1 and refers to the *first* film, and includes only the range 1-3.
  * Any numbers outside that range should throw an error.
  * The Error must mention the name of your favorite _extra cheesy_ movie.
  *

--- a/index.js
+++ b/index.js
@@ -94,6 +94,7 @@ function getNthFilm (character, filmNumber) {
  * ### Challenge `getCargoCapacityTotal`
  * @instructions
  * Sum the total cargo capacity for *all* vehicles and starships.
+ * Some objects may not have a value for their cargo capacity.
  *
  * Sample data expected output: 80124
 */
@@ -106,6 +107,7 @@ function getCargoCapacityTotal (character) {
  * @instructions
  * Find the fastest starship (by atmospheric speed.)
  * Determine the correct field to compare, and return the name of the fastest.
+ * If the character does not have any starships, then return 'none'.
  *
  * Sample data expected output: `X-wing`
 */
@@ -118,6 +120,7 @@ function getFastestStarshipName (character) {
  * @instructions
  * Determine the starship with the largest cargo capacity.
  * Return it's **_model_** property.
+ * If the character does not have any starships, then return 'none'.
  *
  * Sample data expected output: `Lambda-class T-4a shuttle`
 */
@@ -129,6 +132,7 @@ function getLargestCargoStarshipModelName (character) {
  * ### Challenge `getSlowestVehicleOrStarshipName`
  * @instructions
  * Find the slowest vehicle OR starship. Return its name.
+ * If the character does not have any starships or vehicles, then return 'none'.
  *
 */
 function getSlowestVehicleOrStarshipName (character) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -92,5 +92,5 @@ describe('getLargestCargoStarshipModelName()', () => {
 describe('getSlowestVehicleOrStarshipName()', () => {
   it('Luke\'s slowest transportation', () => { expect(getSlowestVehicleOrStarshipName(lukeSkywalker)).to.eq(`Imperial Speeder Bike`) })
   it('Leia\'s slowest transportation', () => { expect(getSlowestVehicleOrStarshipName(leiaOrgana)).to.eq(`Imperial Speeder Bike`) })
-  it('Obi-Wan\'s slowest transportation', () => { expect(getSlowestVehicleOrStarshipName(obiWanKenobi)).to.eq(`Jedi starfighter`) })
+  it('Obi-Wan\'s slowest transportation', () => { expect(getSlowestVehicleOrStarshipName(obiWanKenobi)).to.eq(`Tribubble bongo`) })
 })


### PR DESCRIPTION
This pull request contains:

- A fix for Obi-Wan's test in `getSlowestVehicleOrStarshipName`
- Additional instructions for `getNthFilm` to emphasize that the `filmNumber` argument is 1-indexed
- Clarification that some values may be `null` or `undefined` in `getCargoCapacityTotal`
- Clarification that some characters may not have ships or vehicles in the functions that use that data.