### PR TITLE
Correct `getStarshipPassengerAndCrewSumTotal` instructions

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,8 @@ function getVehiclesCostInCreditsSumTotal (character) {
 /**
  * ### Challenge `getStarshipPassengerAndCrewSumTotal`
  * @instructions
- * Sum the number of crew and passenger spots in both vehicles and starships.
+ * Sum the number of crew and passenger spots for all starships defined on the
+ * input character.
  *
  * Sample data expected output: 27
 */


### PR DESCRIPTION
The instructions mistakenly mention to sum the crew and passengers for all
starships and vehicles, when the function name and tests expect only starships
to be considered.

The language was brought in line with the instructions on other functions.